### PR TITLE
修复tcpConnector中OnDispose触发两次问题

### DIFF
--- a/src/CatLib.Framework/Socket/TcpConnector.cs
+++ b/src/CatLib.Framework/Socket/TcpConnector.cs
@@ -223,7 +223,8 @@ namespace CatLib.Socket
             if (status == Status.Closed)
             {
                 return;
-            }            
+            }
+            
             status = Status.Closed;
             
             if (networkStream != null)

--- a/src/CatLib.Framework/Socket/TcpConnector.cs
+++ b/src/CatLib.Framework/Socket/TcpConnector.cs
@@ -223,8 +223,9 @@ namespace CatLib.Socket
             if (status == Status.Closed)
             {
                 return;
-            }
-
+            }            
+            status = Status.Closed;
+            
             if (networkStream != null)
             {
                 networkStream.Close();
@@ -234,8 +235,7 @@ namespace CatLib.Socket
             {
                 client.Close();
             }
-
-            status = Status.Closed;
+            
             Trigger(SocketEvents.Closed, this);
         }
 


### PR DESCRIPTION
在dispose中没有将status提前设置，networkStream.close就会再次触发dispose。